### PR TITLE
ボタンの仕様変更。Libra画面の仕様変更。

### DIFF
--- a/TeamZenmaiSiki/Assets/Scenes/Battle.unity
+++ b/TeamZenmaiSiki/Assets/Scenes/Battle.unity
@@ -273,10 +273,10 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1927049488}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -60, y: 200}
+  m_AnchoredPosition: {x: -60, y: 60}
   m_SizeDelta: {x: 120, y: 120}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &163999380
@@ -301,7 +301,7 @@ MonoBehaviour:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -313,7 +313,7 @@ MonoBehaviour:
     m_HighlightedTrigger: Highlighted
     m_PressedTrigger: Pressed
     m_DisabledTrigger: Disabled
-  m_Interactable: 1
+  m_Interactable: 0
   m_TargetGraphic: {fileID: 163999381}
   m_OnClick:
     m_PersistentCalls:
@@ -407,7 +407,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1927049488}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: -60, y: 60}
@@ -435,7 +435,7 @@ MonoBehaviour:
     m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
     m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
     m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
-    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.553}
     m_ColorMultiplier: 1
     m_FadeDuration: 0.1
   m_SpriteState:
@@ -1146,8 +1146,8 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 300956833}
   - {fileID: 163999379}
+  - {fileID: 300956833}
   m_Father: {fileID: 424342314}
   m_RootOrder: 0
   m_AnchorMin: {x: 1, y: 0}

--- a/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/TurnManager/BattleButton.cs
+++ b/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/TurnManager/BattleButton.cs
@@ -5,5 +5,6 @@ public class BattleButton : MonoBehaviour {
     public void BattleStart()
     {
         TurnManager.Instance.ProgressFunction();
+        Destroy(this.gameObject);
     }
 }

--- a/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/TurnManager/TurnManager.cs
+++ b/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/TurnManager/TurnManager.cs
@@ -50,6 +50,7 @@ public class TurnManager : MonoBehaviour {
     private List<Functions> turnFunctions;  //ターンのフェーズごとに関数に格納
     private int functionNumber;             //現在の関数のID
     private int oldID;                      //1フレーム前のFunctionID
+    private bool libraCheck;                //Libra画面を一度確認したかどうか。
 
     void Awake()
     {
@@ -85,6 +86,10 @@ public class TurnManager : MonoBehaviour {
     /// </summary>
     void Libra()
     {
+        if (libraCheck)
+        {
+            ProgressFunction();
+        }
         //TODO:長押しで情報表示
         //Debug.Log("Libra");
     }
@@ -94,6 +99,7 @@ public class TurnManager : MonoBehaviour {
     /// </summary>
     void PlayerAttack()
     {
+        if (!libraCheck) libraCheck = true;
         playerAttackController.GenerateAttackCircle();
     }
 
@@ -106,37 +112,13 @@ public class TurnManager : MonoBehaviour {
     }
 
     /// <summary>
-    /// フェーズごとにボタンの状態を管理する。
+    /// ボタンの状態を変更。
     /// </summary>
-    void ButtonManagement()
+    public void ButtonManagement()
     {
-        //ターン先頭（Libra関数）での処理
-        if (functionNumber == (int)FunctionID.LIBRA)
+        if (EnemyLast())
         {
-            if (!EnemyLast())
-            {
-                buttonManager[(int)ButtonID.AVOID].SetInteractable(false);
-                buttonManager[(int)ButtonID.ATTACK].SetInteractable(true);
-            }
-            else
-            {
-                buttonManager[(int)ButtonID.AVOID].SetInteractable(true);
-                buttonManager[(int)ButtonID.ATTACK].SetInteractable(true);
-            }
-        }
-
-        //プレイヤーのアタックフェーズ時処理
-        if (functionNumber == (int)FunctionID.PLAYER_ATTACK)
-        {
-            buttonManager[(int)ButtonID.AVOID].SetInteractable(false);
-            buttonManager[(int)ButtonID.ATTACK].SetInteractable(false);
-        }
-
-        //エネミーのアタックフェーズ時処理
-        if (functionNumber == (int)FunctionID.ENEMY_ATTACK)
-        {
-            buttonManager[(int)ButtonID.AVOID].SetInteractable(false);
-            buttonManager[(int)ButtonID.ATTACK].SetInteractable(false);
+            CanAvoid();
         }
     }
 
@@ -145,6 +127,7 @@ public class TurnManager : MonoBehaviour {
     /// </summary>
     private void SetupTurnFunctions()
     {
+        libraCheck = false;
         functionNumber = 0;
         turnFunctions = new List<Functions>();
         turnFunctions.Add(Libra);
@@ -170,6 +153,14 @@ public class TurnManager : MonoBehaviour {
     {
         if (EnemyManager.Instance.GetEnemyElems() == (int)EnemyElements.NOTHING) return true;
         return false;
+    }
+
+    /// <summary>
+    /// 逃げるボタンを有効化。
+    /// </summary>
+    private void CanAvoid()
+    {
+        buttonManager[(int)ButtonID.AVOID].SetInteractable(true);
     }
 
     public void ProgressFunction() { functionNumber++; }

--- a/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/UpdateManager/PlayerAttackUpdateManager.cs
+++ b/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/UpdateManager/PlayerAttackUpdateManager.cs
@@ -64,6 +64,7 @@ public class PlayerAttackUpdateManager : MonoBehaviour {
             Destroy(targetObject);
             EnemyManager.Instance.EnemyPosErase();
             playerAttackController.DecreaseCurrentTargetIndex();
+            TurnManager.Instance.ButtonManagement();
             isHit = false;
         }
     }


### PR DESCRIPTION
戦うボタンは1回の戦闘中の開始時1回のみ押せるようにし。押すとそこが無効化状態の逃げるボタンに差し変わるように変更。
また、Libra画面も1回の戦闘の初めの1回のみ通るようにし、以降は敵の攻撃と自分の攻撃のフェーズを交互に行き来するように変更。