### PR TITLE
戦闘ごとのKillNameをDataManagerにAddするように変更。

### DIFF
--- a/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/Enemy/EnemyManager.cs
+++ b/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/Enemy/EnemyManager.cs
@@ -139,23 +139,6 @@ public class EnemyManager : MonoBehaviour {
 
         collisionData = new CollisionData();
         CollisionIndex = collisionData.CollisionIndex;
-
-        //デバッグ用:配列デバッグ用
-        //for (int k = 0; k < EnemyElems; k++)
-        //{
-        //    for (int i = 0; i < 30; i++)
-        //    {
-        //        string a = "";
-        //        for (int j = 0; j < 30; j++)
-        //        {
-        //            a += CollisionIndex[k][i][j].ToString();
-        //        }
-        //        Debug.Log(a);
-        //    }
-        //    Debug.Log("===================================================");
-        //    Debug.Log("===================================================");
-        //    Debug.Log("===================================================");
-        //}
     }
 
     /// <summary>
@@ -163,8 +146,6 @@ public class EnemyManager : MonoBehaviour {
     /// </summary>
     public void EnemyErase()
     {
-        DataManager.Instance.KillNum++;
-        DataManager.Instance.KillNames.Add(BattleManager.Instance.getKillName(CurrentTargetIndex));
         BattleManager.Instance.removeEnemyData(CurrentTargetIndex);
         Enemies.RemoveAt(CurrentTargetIndex);
         Pos.RemoveAt(CurrentTargetIndex);
@@ -250,4 +231,15 @@ public class EnemyManager : MonoBehaviour {
         if (EnemyElems == 0) return true;
         else                 return false;
     }
+
+	/// <summary>
+	/// Killした敵の情報をDataManagerに登録。
+	/// </summary>
+	public void RegisterKillData()
+	{
+		string _killName = BattleManager.Instance.getKillName(CurrentTargetIndex);
+		DataManager.Instance.KillNum++;
+		DataManager.Instance.KillNames.Add(_killName);
+		DataManager.Instance.IsTargetKilled.Add(_killName);
+	}
 }

--- a/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/UpdateManager/PlayerAttackUpdateManager.cs
+++ b/TeamZenmaiSiki/Assets/Scripts/Marumoto/Battle/UpdateManager/PlayerAttackUpdateManager.cs
@@ -111,6 +111,7 @@ public class PlayerAttackUpdateManager : MonoBehaviour {
     private void EnemyDestroy()
     {
         Destroy(EnemyManager.Instance.Enemies[EnemyManager.Instance.CurrentTargetIndex]);
+		EnemyManager.Instance.RegisterKillData();
         EnemyManager.Instance.EnemyErase();
         playerAttackController.DecreaseCurrentTargetIndex();
         TurnManager.Instance.ButtonManagement();

--- a/TeamZenmaiSiki/Assets/Scripts/Marumoto/Note/Note/Canvas/CanvasManager.cs
+++ b/TeamZenmaiSiki/Assets/Scripts/Marumoto/Note/Note/Canvas/CanvasManager.cs
@@ -46,8 +46,6 @@ public class CanvasManager : MonoBehaviour {
         }
     }
 
-    
-
     //デバッグ用:CSVデータ読み込みの正確性確認用。
     /// <summary>
     /// CSVデータが正しく読み込まれているかのデバッグ出力関数。


### PR DESCRIPTION
DataManagerへの登録が肥大化したのでEnemyErase()から分離、RegisterKillData()を新規作成。